### PR TITLE
Some more cleanups for the CI/CD pipeline

### DIFF
--- a/openshift/configmap-template.yaml
+++ b/openshift/configmap-template.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     description: This is Thoth Core - All the configmaps required to deploy Thoth Core Analyzer and Results API 
     openshift.io/display-name: Thoth Core Configmap
-    version: 0.1.0
+    version: 0.2.0
     tags: poc,thoth,ai-stacks
     template.openshift.io/documentation-url: https://github.com/AICoE/Thoth/
     template.openshift.io/long-description: This template defines resources needed to deploy Thoth Core Services as a Proof-of-Concept to OpenShift.
@@ -40,6 +40,7 @@ objects:
     analyzer-cleanup-time: ${THOTH_ANALYZER_CLEANUP_TIME}
     sync-observations: ${THOTH_SYNC_OBSERVATIONS}
     debug-cleanup: ${THOTH_CLEANUP_DEBUG}
+    package-releases-only-if-package-seen: ${THOTH_PACKAGE_RELEASES_ONLY_IF_PACKAGE_SEEN}
 
 parameters:
 - description: Name of the Thoth Frontend Namespace
@@ -97,3 +98,9 @@ parameters:
   required: true
   value: thoth-test
   name: THOTH_DEPLOYMENT_NAME
+
+- displayName: THOTH_PACKAGE_RELEASES_ONLY_IF_PACKAGE_SEEN
+  description: Only insert packages that have been seen within the Graph database.
+  name: THOTH_PACKAGE_RELEASES_ONLY_IF_PACKAGE_SEEN
+  required: true
+  value: 1

--- a/openshift/manual-graph-sync-job.yaml
+++ b/openshift/manual-graph-sync-job.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: manual-graph-sync-batchjob
+  labels:
+    app: thoth-core
+    ops-mode: manual
+spec:
+  containers:
+  - name: graph-sync-batchjob
+    image: graph-sync-cronjob
+    env:
+    - name: THOTH_DEPLOYMENT_NAME
+      valueFrom:
+        configMapKeyRef:
+          key: storage-bucket-name
+          name: thoth
+    - name: THOTH_JANUSGRAPH_HOST
+      value: janusgraph
+    - name: THOTH_JANUSGRAPH_PORT
+      value: '80'
+    - name: THOTH_GRAPH_SYNC_DEBUG
+      value: '1'
+    - name: THOTH_LOG_STORAGES
+      value: 'DEBUG'
+    - name: THOTH_SYNC_OBSERVATIONS
+      valueFrom:
+        configMapKeyRef:
+          key: sync-observations
+          name: thoth
+    - name: THOTH_CEPH_HOST
+      valueFrom:
+        configMapKeyRef:
+          key: ceph-host
+          name: thoth
+    - name: THOTH_CEPH_BUCKET
+      valueFrom:
+        configMapKeyRef:
+          key: ceph-bucket-name
+          name: thoth
+    - name: THOTH_CEPH_BUCKET_PREFIX
+      valueFrom:
+        configMapKeyRef:
+          key: ceph-bucket-prefix
+          name: thoth
+    - name: THOTH_CEPH_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: thoth
+          key: ceph-key-id
+    - name: THOTH_CEPH_SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: thoth
+          key: ceph-secret-key
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "125m"
+      limits:
+        memory: "256Mi"
+        cpu: "500m"
+  restartPolicy: Never

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -470,37 +470,6 @@ objects:
 - apiVersion: v1
   kind: BuildConfig
   metadata:
-    name: user-api
-    namespace: ${THOTH_FRONTEND_NAMESPACE}
-    labels:
-      app: thoth-core
-  spec:
-    output:
-      to:
-        kind: ImageStreamTag
-        name: user-api:latest
-    source:
-      type: Git
-      git:
-        uri: ${THOTH_USER_API_GIT_URL}
-      secrets: []
-    strategy:
-      type: Source
-      sourceStrategy:
-        from:
-          kind: ImageStreamTag
-          name: python:latest
-    triggers:
-    - github:
-        secret: ${THOTH_USER_API_GITHUB_SECRET}
-      type: GitHub
-    - type: ConfigChange
-    - imageChange: {}
-      type: ImageChange
-
-- apiVersion: v1
-  kind: BuildConfig
-  metadata:
     name: result-api
     namespace: ${THOTH_MIDDLEEND_NAMESPACE}
     labels:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -386,6 +386,11 @@ objects:
             - image: thoth-graph-sync-job
               name: graph-sync-cronjob
               env:
+              - name: THOTH_DEPLOYMENT_NAME
+                valueFrom:
+                  configMapKeyRef:
+                    key: storage-bucket-name
+                    name: thoth
               - name: THOTH_JANUSGRAPH_HOST
                 value: janusgraph
               - name: THOTH_JANUSGRAPH_PORT

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -331,6 +331,8 @@ objects:
   spec:
     schedule: "@weekly"
     suspend: true
+    successfulJobsHistoryLimit: 4
+    failedJobsHistoryLimit: 1
     jobTemplate:
       spec:
         template:
@@ -338,7 +340,7 @@ objects:
             serviceAccountName: analyzer
             containers:
             - image: thoth-cleanup-job
-              name: cleanup-job
+              name: cleanup-cronjob
               env:
                - name: KUBERNETES_VERIFY_TLS
                  value: "0"
@@ -373,13 +375,16 @@ objects:
   spec:
     schedule: "@daily"
     suspend: true
+    successfulJobsHistoryLimit: 5
+    failedJobsHistoryLimit: 1
+    concurrencyPolicy: Forbid
     jobTemplate:
       spec:
         template:
           spec:
             containers:
             - image: thoth-graph-sync-job
-              name: graph-sync-job
+              name: graph-sync-cronjob
               env:
               - name: THOTH_JANUSGRAPH_HOST
                 value: janusgraph

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -118,7 +118,7 @@ objects:
           - name: KUBERNETES_API_URL
             value: 'https://kubernetes.default.svc.cluster.local'
           - name: KUBERNETES_VERIFY_TLS
-            value: ${KUBERNETES_VERIFY_TLS}
+            value: "0"
           - name: THOTH_RESULT_API_HOSTNAME
             value: thoth-result-api
           - name: THOTH_RESULT_API_URL
@@ -329,8 +329,7 @@ objects:
     labels:
       app: thoth-core
   spec:
-    #schedule: "@weekly"
-    schedule: "*/1 * * * *"
+    schedule: "@weekly"
     suspend: true
     jobTemplate:
       spec:
@@ -338,11 +337,11 @@ objects:
           spec:
             serviceAccountName: analyzer
             containers:
-            - image: fridex/thoth-cleanup-job
+            - image: thoth-cleanup-job
               name: cleanup-job
               env:
                - name: KUBERNETES_VERIFY_TLS
-                 value: ${KUBERNETES_VERIFY_TLS}
+                 value: "0"
                - name: THOTH_ANALYZER_CLEANUP_TIME
                  valueFrom:
                   configMapKeyRef:
@@ -372,14 +371,14 @@ objects:
     labels:
       app: thoth-core
   spec:
-    schedule: "@weekly"
+    schedule: "@daily"
     suspend: true
     jobTemplate:
       spec:
         template:
           spec:
             containers:
-            - image: fridex/thoth-graph-sync-job
+            - image: thoth-graph-sync-job
               name: graph-sync-job
               env:
               - name: THOTH_JANUSGRAPH_HOST
@@ -567,12 +566,6 @@ parameters:
   displayName: Sync observations
   required: true
   name: THOTH_SYNC_OBSERVATIONS
-  value: '0'
-
-- description: Verify TLS certificates of Kubernetes master on requests.
-  displayName: Verify Kubernetes TLS
-  required: true
-  name: KUBERNETES_VERIFY_TLS
   value: '0'
 
 - description: Storage bucket name to use for persisted files

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -497,7 +497,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: python:latest
+          name: python-36-centos7:latest
           namespace: ${THOTH_FRONTEND_NAMESPACE}
       type: Source
     triggers:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -439,7 +439,7 @@ objects:
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    name: python
+    name: python-36-centos7
     namespace: ${THOTH_FRONTEND_NAMESPACE}
     annotations:
       openshift.io/display-name: Python

--- a/playbooks/provision.yaml
+++ b/playbooks/provision.yaml
@@ -7,15 +7,15 @@
   vars:
     openshift_master_url: "{{ lookup('env','OCP_URL') }}"
     token: "{{ lookup('env','OCP_TOKEN') }}"
-    THOTH_BACKEND_NAMESPACE: "thoth-test-back"
-    THOTH_MIDDLEEND_NAMESPACE: "thoth-test-middle"
-    THOTH_FRONTEND_NAMESPACE: "thoth-test-front"
+    THOTH_BACKEND_NAMESPACE: "goern-dev-thoth"
+    THOTH_MIDDLEEND_NAMESPACE: "goern-dev-thoth"
+    THOTH_FRONTEND_NAMESPACE: "goern-dev-thoth"
+    THOTH_DEPLOYMENT_NAME: "goern-dev-thoth"
     THOTH_CEPH_SECRET_KEY: "{{ lookup('env','THOTH_CEPH_SECRET_KEY') }}"
     THOTH_CEPH_KEY_ID: "{{ lookup('env','THOTH_CEPH_KEY_ID') }}"
-    THOTH_CEPH_HOST: "{{ lookup('env','THOTH_CEPH_HOST') }}"
+    THOTH_CEPH_HOST: "{{ lookup('env','THOTH_S3_ENDPOINT_URL') }}"
     THOTH_CEPH_BUCKET: "DH-DEV-DATA"
     THOTH_SECRET: "{{ lookup('env','THOTH_SECRET') }}"
-    THOTH_DEPLOYMENT_NAME: "test"
     
   gather_facts: false
   connection: local

--- a/playbooks/provision.yaml
+++ b/playbooks/provision.yaml
@@ -13,7 +13,7 @@
     THOTH_DEPLOYMENT_NAME: "goern-dev-thoth"
     THOTH_CEPH_SECRET_KEY: "{{ lookup('env','THOTH_CEPH_SECRET_KEY') }}"
     THOTH_CEPH_KEY_ID: "{{ lookup('env','THOTH_CEPH_KEY_ID') }}"
-    THOTH_CEPH_HOST: "{{ lookup('env','THOTH_S3_ENDPOINT_URL') }}"
+    THOTH_CEPH_HOST: "{{ lookup('env','THOTH_CEPH_HOST') }}"
     THOTH_CEPH_BUCKET: "DH-DEV-DATA"
     THOTH_SECRET: "{{ lookup('env','THOTH_SECRET') }}"
     


### PR DESCRIPTION
- manual-graph-sync-batchjob added
- KUBERNETES_VERIFY_TLS hardcoded to 0
- removed user-api BuildConfig as it is part of its own repo/pipeline
- renamed THOTH_CEPH_HOST to THOTH_S3_ENDPOINT_URL
- removed repository name from image of cronjobs