### PR TITLE
Feature: End-to-End Tests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,19 @@
+[[source]]
+
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+
+[packages]
+
+pytest = "*"
+pylint = "*"
+"autopep8" = "*"
+behave = "*"
+pyhamcrest = "*"
+requests = "*"
+
+
+[dev-packages]
+

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,224 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "04eb872ec5ca1e4637754dbe5fad1b4bc1d2efaeda3dd1a2fff2ff1d7535641f"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.6.5",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "4.15.14-300.fc27.x86_64",
+            "platform_system": "Linux",
+            "platform_version": "#1 SMP Thu Mar 29 16:13:44 UTC 2018",
+            "python_full_version": "3.6.5",
+            "python_version": "3.6",
+            "sys_platform": "linux"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "astroid": {
+            "hashes": [
+                "sha256:38186e481b65877fd8b1f9acc33e922109e983eb7b6e487bd4c71002134ad331",
+                "sha256:35cfae47aac19c7b407b7095410e895e836f2285ccf1220336afba744cc4c5f2"
+            ],
+            "version": "==1.6.3"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450",
+                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9"
+            ],
+            "version": "==17.4.0"
+        },
+        "autopep8": {
+            "hashes": [
+                "sha256:2284d4ae2052fedb9f466c09728e30d2e231cfded5ffd7b1a20c34123fdc4ba4"
+            ],
+            "version": "==1.3.5"
+        },
+        "behave": {
+            "hashes": [
+                "sha256:ebda1a6c9e5bfe95c5f9f0a2794e01c7098b3dde86c10a95d8621c5907ff6f1c",
+                "sha256:b9662327aa53294c1351b0a9c369093ccec1d21026f050c3bd9b3e5cccf81a86"
+            ],
+            "version": "==1.2.6"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0",
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7"
+            ],
+            "version": "==2018.4.16"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
+            ],
+            "version": "==2.6"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497",
+                "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
+                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8"
+            ],
+            "version": "==4.3.4"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
+                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
+                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
+                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
+                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
+                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
+                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
+                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
+                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
+                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
+                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
+                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
+                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
+                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
+                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
+                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
+                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
+                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b",
+                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
+                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
+                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
+                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
+                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
+                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
+                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
+                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
+                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
+                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
+                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a"
+            ],
+            "version": "==1.3.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:11a625025954c20145b37ff6309cd54e39ca94f72f6bb9576d1195db6fa2442e",
+                "sha256:0dd8f72eeab0d2c3bd489025bb2f6a1b8342f9b198f6fc37b52d15cfa4531fea",
+                "sha256:c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44"
+            ],
+            "version": "==4.1.0"
+        },
+        "parse": {
+            "hashes": [
+                "sha256:8048dde3f5ca07ad7ac7350460952d83b63eaacecdac1b37f45fd74870d849d2"
+            ],
+            "version": "==1.8.2"
+        },
+        "parse-type": {
+            "hashes": [
+                "sha256:6e906a66f340252e4c324914a60d417d33a4bea01292ea9bbf68b4fc123be8c9",
+                "sha256:f596bdc75d3dd93036fbfe3d04127da9f6df0c26c36e01e76da85adef4336b3c"
+            ],
+            "version": "==0.4.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5",
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+            ],
+            "version": "==0.6.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a",
+                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881"
+            ],
+            "version": "==1.5.3"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
+                "sha256:74abc4e221d393ea5ce1f129ea6903209940c1ecd29e002e8c6933c2b21026e0",
+                "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
+            ],
+            "version": "==2.4.0"
+        },
+        "pyhamcrest": {
+            "hashes": [
+                "sha256:f30e9a310bcc1808de817a92e95169ffd16b60cbc5a016a49c8d0e8ababfae79",
+                "sha256:6b672c02fdf7470df9674ab82263841ce8333fb143f32f021f6cb26f0e512420",
+                "sha256:bac0bea7358666ce52e3c6c85139632ed89f115e9af52d44b3c36e0bf8cf16a9",
+                "sha256:7a4bdade0ed98c699d728191a058a60a44d2f9c213c51e2dd1e6fb42f2c6128a",
+                "sha256:8ffaa0a53da57e89de14ced7185ac746227a8894dbd5a3c718bf05ddbd1d56cd"
+            ],
+            "version": "==1.9.0"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:0b7e6b5d9f1d4e0b554b5d948f14ed7969e8cdf9a0120853e6e5af60813b18ab",
+                "sha256:34738a82ab33cbd3bb6cd4cef823dbcabdd2b6b48a4e3a3054a2bbbf0c712be9"
+            ],
+            "version": "==1.8.4"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:6266f87ab64692112e5477eba395cfedda53b1933ccd29478e671e73b420c19c",
+                "sha256:fae491d1874f199537fd5872b5e1f0e74a009b979df9d53d1553fd03da1703e1"
+            ],
+            "version": "==3.5.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
+                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+            ],
+            "version": "==2.18.4"
+        },
+        "six": {
+            "hashes": [
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+            ],
+            "version": "==1.11.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
+                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+            ],
+            "version": "==1.22"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:d4d560d479f2c21e1b5443bbd15fe7ec4b37fe7e53d335d3b9b0a7b1226fe3c6"
+            ],
+            "version": "==1.10.11"
+        }
+    },
+    "develop": {}
+}

--- a/features/analyse_container_image.feature
+++ b/features/analyse_container_image.feature
@@ -1,0 +1,27 @@
+Feature: Analyse Container Image
+
+    Background: Test Environment
+        Given I am using the TEST environement
+
+    @wip
+    Scenario Outline: Submitting a Container Image for analysis
+        When I submit <a container image> to the User API for analysis by <analyser image>
+        Then I want to receive a Analyser Job ID
+        And I wait for the Analyser Job to finish successful
+        And the Analyzer Job Log should not be empty
+
+        Examples: Container Image and Analysers
+            | a container image | analyser image               |
+            | fedora:27         | fridex/thoth-package-extract |
+
+    @wip
+    Scenario: Query for currently available Analyser Results
+        When I query the Result API for a list of analyser results
+        Then the list of results should not be empty
+
+    @wip
+    Scenario: Get the Analyser Results for my last submitted Container Image
+        When I query the Result API for my latest analyser result
+        Then the result should not be empty
+        And the analyser should be "thoth-package-extract"
+        And the analyser version should be "1.0.0"

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,21 @@
+# -*- coding: UTF-8 -*-
+"""
+before_step(context, step), after_step(context, step)
+    These run before and after every step.
+    The step passed in is an instance of Step.
+before_scenario(context, scenario), after_scenario(context, scenario)
+    These run before and after each scenario is run.
+    The scenario passed in is an instance of Scenario.
+before_feature(context, feature), after_feature(context, feature)
+    These run before and after each feature file is exercised.
+    The feature passed in is an instance of Feature.
+before_tag(context, tag), after_tag(context, tag)
+"""
+
+# -- SETUP: Use cfparse as default matcher
+# from behave import use_step_matcher
+# step_matcher("cfparse")
+
+
+def before_all(context):
+    context.config.setup_logging()

--- a/features/result_api.feature
+++ b/features/result_api.feature
@@ -1,0 +1,18 @@
+Feature: Result API
+
+As a container image maintainer,
+I want to query Thoth for a stack analysis,
+so that I get a complete dump of the stack including observations and recommendations.
+
+    Scenario: Query for currently available Results
+        Given I am using the TEST environement
+        When I query the Result API for a list of analyser results
+        Then the list of analyser results should not be empty
+
+    Scenario: Get one of the for currently available Results
+        Given I am using the TEST environement
+        When I query the Result API for a list of analyser results
+        And I get one of the results
+        Then the analyser result should not be empty
+        And the analyser should be "thoth-package-extract"
+        And the analyser version should be "1.0.0"

--- a/features/result_api.feature
+++ b/features/result_api.feature
@@ -4,15 +4,28 @@ As a container image maintainer,
 I want to query Thoth for a stack analysis,
 so that I get a complete dump of the stack including observations and recommendations.
 
-    Scenario: Query for currently available Results
+    Scenario: Query for currently available Analyser Results
         Given I am using the TEST environement
         When I query the Result API for a list of analyser results
-        Then the list of analyser results should not be empty
+        Then the list of results should not be empty
 
-    Scenario: Get one of the for currently available Results
+    Scenario: Get one of the for currently available Analyser Results
         Given I am using the TEST environement
         When I query the Result API for a list of analyser results
-        And I get one of the results
-        Then the analyser result should not be empty
+        And I get one of the analyser results
+        Then the result should not be empty
         And the analyser should be "thoth-package-extract"
         And the analyser version should be "1.0.0"
+
+    Scenario: Query for currently available Solver Results
+        Given I am using the TEST environement
+        When I query the Solver API for a list of solver results
+        Then the list of results should not be empty
+
+    Scenario: Get one of the for currently available Solver Results
+        Given I am using the TEST environement
+        When I query the Solver API for a list of solver results
+        And I get one of the solver results
+        Then the result should not be empty
+        And the solver should be "thoth-solver"
+        And the solver version should be "1.0.1"

--- a/features/steps/result_api_steps.py
+++ b/features/steps/result_api_steps.py
@@ -16,7 +16,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Thoth: Core: End-to-End Tests: Result API feature tests."""
+"""Thoth: Core: End-to-End Tests: Result API feature test steps."""
 
 from http import HTTPStatus
 

--- a/features/steps/result_api_steps.py
+++ b/features/steps/result_api_steps.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#   thoth-core
+#   Copyright(C) 2018 Christoph Görn
+#
+#   This program is free software: you can redistribute it and / or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Thoth: Core: End-to-End Tests: Result API feature tests."""
+
+from http import HTTPStatus
+
+import requests
+
+from behave import given, when, then
+from hamcrest import assert_that, equal_to, is_not, not_none
+
+
+@given('I am using the TEST environement')
+def step_impl(context):
+    # TODO read this from ENV
+    context.endpoint_url = 'http://user-api-thoth-test-core.cloud.upshift.engineering.redhat.com/api/v1/analyze'
+
+
+@when('I query the Result API for a list of analyser results')
+def step_impl(context):
+    r = requests.get(context.endpoint_url)
+
+    assert_that(r.status_code, equal_to(HTTPStatus.OK))
+    assert_that(r.headers['content-type'], equal_to('application/json'))
+
+    result_list = r.json()
+    assert_that(result_list, not_none)
+    context.result_list = result_list['results']
+
+
+@when('I get one of the results')
+def step_impl(context):
+    assert_that(len(context.result_list), not equal_to(0))
+
+    # TODO this could be a little bit more random choice
+    context.chosen_result = context.result_list[0]
+
+    r = requests.get(f'{context.endpoint_url}/{context.chosen_result}')
+    assert_that(r.status_code, equal_to(HTTPStatus.OK))
+    assert_that(r.headers['content-type'], equal_to('application/json'))
+
+    chosen_result_json = r.json()
+    assert_that(chosen_result_json, not_none)
+    context.chosen_result_json = chosen_result_json
+
+
+@then('the list of analyser results should not be empty')
+def step_impl(context):
+    assert_that(len(context.result_list), not equal_to(0))
+
+
+@then('the analyser result should not be empty')
+def step_impl(context):
+    assert_that(context.chosen_result, not_none)
+
+
+@then('the analyser should be "{name}"')
+def step_impl(context, name):
+    assert_that(context.chosen_result_json['metadata']['analyzer'],
+                equal_to(name))
+
+
+@then('the analyser version should be "{version}"')
+def step_impl(context, version):
+    assert_that(context.chosen_result_json['metadata']['analyzer_version'],
+                equal_to(version))

--- a/features/steps/user_api_steps.py
+++ b/features/steps/user_api_steps.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#   thoth-core
+#   Copyright(C) 2018 Christoph Görn
+#
+#   This program is free software: you can redistribute it and / or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Thoth: Core: End-to-End Tests: User API feature test steps."""
+
+import time
+
+from http import HTTPStatus
+
+import requests
+
+from behave import given, when, then
+from hamcrest import assert_that, equal_to, is_not, not_none, less_than
+
+
+@when(u'I submit {a_container_image} to the User API for analysis by {analyser_image}')
+def step_impl(context, a_container_image, analyser_image):
+    payload = {
+        'image': a_container_image,
+        'analyzer': analyser_image
+    }
+
+    r = requests.post(f'{context.endpoint_url}/analyze', params=payload)
+
+    assert_that(r.status_code, equal_to(HTTPStatus.ACCEPTED))
+    assert_that(r.headers['content-type'], equal_to('application/json'))
+
+    response = r.json()
+    assert_that(response, not_none)
+    context.response = response
+
+
+@when(u'I query the Result API for my latest analyser result')
+def step_impl(context):
+    payload = {
+        'pod_id': context.analyzer_job_id
+    }
+    r = requests.get(
+        f'{context.endpoint_url}/log', params=payload)
+
+    assert_that(r.status_code, equal_to(HTTPStatus.OK))
+    assert_that(r.headers['content-type'], equal_to('application/json'))
+
+    analyzer_job_log = r.json()
+    assert_that(analyzer_job_log, not_none)
+
+    assert_that(analyzer_job_log['pod_id'], equal_to(context.analyzer_job_id))
+
+    context.analyzer_job_log = analyzer_job_log
+
+
+@then(u'I want to receive a Analyser Job ID')
+def step_impl(context):
+    assert_that(context.response, not_none)
+
+    analyzer_job_id = context.response['pod_id']
+    assert_that(analyzer_job_id, not_none)
+
+    context.analyzer_job_id = analyzer_job_id
+
+
+@then(u'I wait for the Analyser Job to finish successful')
+def step_impl(context):
+    time.sleep(15)
+
+    analyzer_job_terminated = False
+    analyzer_job_termination_retries = 0
+
+    while not analyzer_job_terminated:
+        time.sleep(5)
+
+        payload = {
+            'pod_id': context.analyzer_job_id
+        }
+        r = requests.get(
+            f'{context.endpoint_url}/status', params=payload)
+
+        assert_that(r.status_code, equal_to(HTTPStatus.OK))
+        assert_that(r.headers['content-type'], equal_to('application/json'))
+
+        response = r.json()
+        assert_that(response, not_none)
+
+        if 'terminated' in response['status'].keys():
+            if response['status']['terminated']['reason'].startswith('Completed'):
+                analyzer_job_terminated = True
+
+        analyzer_job_termination_retries += 1
+
+        assert_that(analyzer_job_termination_retries, less_than(10))
+
+
+@then(u'the Analyzer Job Log should not be empty')
+def step_impl(context):
+    payload = {
+        'pod_id': context.analyzer_job_id
+    }
+    r = requests.get(
+        f'{context.endpoint_url}/log', params=payload)
+
+    assert_that(r.status_code, equal_to(HTTPStatus.OK))
+    assert_that(r.headers['content-type'], equal_to('application/json'))
+
+    analyzer_job_log = r.json()
+    assert_that(analyzer_job_log, not_none)
+
+    assert_that(analyzer_job_log['pod_id'], equal_to(context.analyzer_job_id))

--- a/openshift/buildConfig-e2e-test-template.yaml
+++ b/openshift/buildConfig-e2e-test-template.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: core-e2e-test-buildconfig
+  thoth: 0.1.0
+metadata:
+  name: core-e2e-test-buildconfig
+  annotations:
+    description: This is Thoth Core End-to-End Test BuildConfig, this template is meant to be used by Jenkins, but could also be used by humans...
+    openshift.io/display-name: 'Thoth Core: End-to-End Test BuildConfig'
+    version: 0.1.0
+    tags: poc,thoth,end-to-end,e2e,test,ai-stacks
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: This is Thoth Core End-to-End Test BuildConfig, this template is meant to be used by Jenkins, but could also be used by humans...
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+
+objects:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: core-e2e-test
+    labels:
+      app: thoth-core
+      component: test
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: "core-e2e-test:${IMAGE_STREAM_TAG}"
+    source:
+      type: Git
+      git:
+        uri: ${GITHUB_URL}
+        ref: ${GITHUB_REF}
+    strategy:
+      type: Source
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: python-36-centos7:latest
+        env:
+          - name: ENABLE_PIPENV
+            value: '1'
+          - name: UPGRADE_PIP_TO_LATEST
+            value: ''
+    triggers:
+    - type: ImageChange
+      imageChange: {}
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: core-e2e-test
+    annotations:
+      openshift.io/display-name: Thoth Core End-to-End Test
+  spec:
+    lookupPolicy:
+      local: true
+      
+parameters:
+- description: Name of the github repository for Thoth's User API
+  displayName: Git Repository
+  required: true
+  name: GITHUB_URL
+  value: 'https://github.com/thoth-station/core'
+
+- description: Git reference to be used for Thoth's User API
+  displayName: Git Reference
+  required: true
+  name: GITHUB_REF
+  value: 'master'
+
+- description: Tag of the output ImageStream the resulting container image should go to
+  displayName: ImageStream Tag
+  required: true
+  name: IMAGE_STREAM_TAG
+  value: 'latest'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[behave]
+logging_clear_handlers=yes
+junit=true
+junit_directory=reports/
+
+stdout_capture = true
+stderr_capture = true

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,4 @@ junit_directory=reports/
 
 stdout_capture = true
 stderr_capture = true
+


### PR DESCRIPTION
This is the first iteration of End-to-End Tests, I cover reading the Result API. Tests use [Behave](http://behave.readthedocs.io/en/stable/index.html) and [Hamcrest](http://pyhamcrest.readthedocs.io/en/latest/tutorial/)

A BuildConfig for a container running the test is included, that container could be started via `oc delete pod core-e2e-test && oc run -ti core-e2e-test --image=core-e2e-test --restart=Never -- /opt/app-root/bin/behave --no-color`

Open Question: How to make this part of the CI? 