### PR TITLE
sesheta is no longer merging on kebechet repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: python
-sudo: required
-services:
-- docker
-python:
-- '3.6'
-script: true

--- a/bots/config.yaml
+++ b/bots/config.yaml
@@ -20,7 +20,6 @@ repositories:
   - lab
   - naming-service
   - misc
-  - kebechet
 defaultLabels:
   - name: 'bot'
     color: '698b69'


### PR DESCRIPTION
I am testing Zuul gating on the kebechet repository, so I dont want sesheta to interfere with that.