### PR TITLE
Use RHEL 8

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -3,9 +3,9 @@ tls_verify: false
 requirements_format: pipenv
 
 runtime_environments:
-  - name: centos:7
+  - name: rhel:8
     operating_system: 
-      name: centos
-      version: "7"
+      name: rhel
+      version: "8"
     python_version: "3.6"
     recommendation_type: latest


### PR DESCRIPTION
So that we resolve software stacks and do not report adviser failures.