### PR TITLE
using Markdown Architectural Decision Records

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,3 +6,15 @@ Welcome to the Thoth-core project README file!
 The main aim for this project is to provide a deployment for Thoth core
 components. For more information about Thoth project and its goals see `the
 Thoth repository <https://github.com/thoth-station/>`_.
+
+Architectural decisions
+-----------------------
+
+We keep track of architectural decisions using a lightweigh architectural decision records. More information on the
+used format is available at https://adr.github.io/madr/. General information about architectural decision records
+is available at `https://adr.github.io/ <https://adr.github.io/>`_.
+
+Architectural decisions
+
+* `ADR-0000 <docs/adr/0000-use-markdown-architectural-decision-records.md>`_ - Use Markdown Architectural Decision Records
+* `ADR-0001 <docs/adr/0001-use-gpl3-as-license.md>`_ - Use GNU GPL as license 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Thoth repository <https://github.com/thoth-station/>`_.
 Architectural decisions
 -----------------------
 
-We keep track of architectural decisions using a lightweigh architectural decision records. More information on the
+We keep track of architectural decisions using lightweight architectural decision records. More information on the
 used format is available at https://adr.github.io/madr/. General information about architectural decision records
 is available at `https://adr.github.io/ <https://adr.github.io/>`_.
 

--- a/docs/adr/0000-use-markdown-architectural-decision-records.md
+++ b/docs/adr/0000-use-markdown-architectural-decision-records.md
@@ -1,0 +1,28 @@
+# Use Markdown Architectural Decision Records
+
+## Context and Problem Statement
+
+We want to record architectural decisions made in Project Thoth. Which format and structure should these records follow?
+
+## Considered Options
+
+* [MADR](https://adr.github.io/madr/) 2.1.2 – The Markdown Architectural Decision Records
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
+* [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) – The Y-Statements
+* Other templates listed at [https://github.com/joelparkerhenderson/architecture\_decision\_record](https://github.com/joelparkerhenderson/architecture_decision_record)
+* Formless – No conventions for file format and structure
+
+## Decision Outcome
+
+Chosen option: "MADR 2.1.2", because
+
+* Implicit assumptions should be made explicit.
+
+  Design documentation is important to enable people understanding the decisions later on.
+
+  See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+
+* The MADR format is lean and fits our development style.
+* The MADR structure is comprehensible and facilitates usage & maintenance.
+* The MADR project is vivid.
+* Version 2.1.2 is the latest one available when starting to document ADRs.

--- a/docs/adr/0001-use-gpl3-as-license.md
+++ b/docs/adr/0001-use-gpl3-as-license.md
@@ -1,0 +1,18 @@
+# Use GNU GPL as license
+
+Everything needs to be licensed, otherwise the default copyright laws apply.
+For instance, in Germany that means users may not alter anything without explicitly asking for permission.
+For more information see <https://help.github.com/articles/licensing-a-repository/>.
+
+We want to have all source code related to Project Thoth to be used without any hassle and as free as possible, so that
+users can just [execute and enjoy the four freedoms](https://fsfe.org/freesoftware/freesoftware.en.html).
+
+## Considered Options
+
+* No license
+* [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)
+* [GNU GPL](http://www.gnu.org/licenses/gpl-3.0.en.html)
+
+## Decision Outcome
+
+Chosen option: "GNU GPL", because this license supports a strong copyleft model.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,74 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->
+
+<!-- markdownlint-disable-file MD013 -->


### PR DESCRIPTION
Using ADR to document architectural decisions, first two on using ADR and GPL are done.

Signed-off-by: Christoph Görn <goern@redhat.com>