### PR TITLE
WIP Update the Devs team(s) and their repo access

### DIFF
--- a/community/github-config.yaml
+++ b/community/github-config.yaml
@@ -1009,13 +1009,13 @@ orgs:
           tensorflow-release-api: triage
           tensorflow-release-job: triage
           termial-random: triage
-          thoth-pybench: triage
           thoth: triage
+          thoth-pybench: triage
           twitter-together: triage
           workflow-helpers: triage
         teams:
           DevOps:
-            description: ""
+            description: This is our DevOps team
             maintainers:
               - goern
               - harshad16
@@ -1027,45 +1027,62 @@ orgs:
             privacy: closed
             repos:
               Github-Issues-Classifier: triage
-              analyzer: triage
-              common: triage
-              cve-update-job: triage
-              datasets: triage
-              graph-refresh-job: triage
-              graph-sync-job: triage
-              httpd-aicoe-container: triage
-              invectio: triage
-              jupyter-notebook: triage
               kebechet-website-tooling: triage
-              management-api: triage
-              metrics-exporter: triage
-              mi: triage
-              mi-scheduler: triage
-              nepthys: triage
-              notebooks: triage
               openblas: triage
-              package-update-job: triage
-              performance: triage
-              python: triage
               rapidsai-build: triage
-              si-bandit: triage
-              srcops-notify-bot: triage
-              srcops-testing: triage
               statusfy: triage
               statusfy-ops: triage
-              stub-api: triage
-              talks: triage
-              tensorflow-build-s2i: triage
-              tensorflow-release-api: triage
-              tensorflow-release-job: triage
-              termial-random: triage
-              thoth: triage
               thoth-ops-infra: triage
-              thoth-pybench: triage
-              twitter-together: triage
-              workflow-helpers: triage
           SourceOps:
             description: This is our SourceOps team, they keep the source fresh.
+            maintainers:
+              - goern
+              - fridex
+              - harshad16
+            members:
+              - codificat
+              - Gregory-Pereira
+              - KPostOffice
+              - mayaCostantini
+              - pacospace
+              - sesheta
+              - sesheta-srcops
+            privacy: closed
+            repos:
+              analyzer: write
+              common: write
+              cve-update-job: write
+              datasets: write
+              graph-refresh-job: write
+              graph-sync-job: write
+              httpd-aicoe-container: write
+              invectio: write
+              jupyter-notebook: write
+              management-api: write
+              metrics-exporter: write
+              mi-scheduler: write
+              mi: write
+              nepthys: write
+              notebooks: write
+              package-update-job: write
+              performance: write
+              prescriptions-refresh-job: write
+              python: write
+              si-bandit: write
+              srcops-notify-bot: write
+              srcops-testing: write
+              stub-api: write
+              talks: write
+              tensorflow-build-s2i: write
+              tensorflow-release-api: write
+              tensorflow-release-job: write
+              termial-random: write
+              thoth-pybench: write
+              thoth: write
+              twitter-together: write
+              workflow-helpers: write
+          Admin:
+            description: This is our Admin team, they take care of our repositores.
             maintainers:
               - goern
               - fridex


### PR DESCRIPTION
## This Pull Request implements

Clean up the Devs team and subteams, and grant some additional access to the core team.

## Description

I found myself as not being able to do some actions that I believe would make our lifes easier. For example: being able to edit an issue description (when I was not the issue creator). This is because I have _triage_ permissions, but this requires _write_ access.

To improve the situation, the suggestion is to have an additional sub-team with that _write_ access level.

Then, I believe that the description of the `SourceOps` subteam was not really accurate: members of that sub-team get _admin_ access to most (all?) repos.

Therefore, the suggestion is to change that sub-team's name to `Admin`, and re-use the `SourceOps` team name for that sub-team with additional _write_ permissions.

Also: the Devs team itself already provides _triage_ access to several repos, and here I am cleaning redundant listing of these repos/access within the `DevOps` sub-team, leaving only the repos that are not listed at the top `Devs` level.


