### PR TITLE
Remove empty references to Slack and Mailing lists

### DIFF
--- a/community/generator/sig_readme.tmpl
+++ b/community/generator/sig_readme.tmpl
@@ -54,8 +54,12 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 
 ## Contact
 
+{{- if .Contact.Slack }}
 - Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+{{- end }}
+{{- if .Contact.MailingList }}
 - [Mailing list]({{.Contact.MailingList}})
+{{- end }}
 {{- if .Label }}
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2F{{.Label}})
 {{- end }}

--- a/community/generator/ug_readme.tmpl
+++ b/community/generator/ug_readme.tmpl
@@ -36,8 +36,12 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{- end }}
 
 ## Contact
+{{- if .Contact.Slack }}
 - Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+{{- end }}
+{{- if .Contact.MailingList }}
 - [Mailing list]({{.Contact.MailingList}})
+{{- end }}
 {{- if .Label }}
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2F{{.Label}})
 {{- end }}

--- a/community/generator/wg_readme.tmpl
+++ b/community/generator/wg_readme.tmpl
@@ -42,8 +42,12 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{- end }}
 
 ## Contact
+{{- if .Contact.Slack }}
 - Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+{{- end }}
+{{- if .Contact.MailingList }}
 - [Mailing list]({{.Contact.MailingList}})
+{{- end }}
 {{- if .Label }}
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2F{{.Label}})
 {{- end }}

--- a/community/sig-docs/README.md
+++ b/community/sig-docs/README.md
@@ -35,9 +35,6 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 * Fridolín Pokorný (**[@fridex](https://github.com/fridex)**), Red Hat
 
 ## Contact
-
-- Slack: [#](https://kubernetes.slack.com/messages/)
-- [Mailing list]()
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fdocs)
 - Steering Committee Liaison: Christoph Görn (**[@goern](https://github.com/goern)**)
 

--- a/community/sig-observability/README.md
+++ b/community/sig-observability/README.md
@@ -35,9 +35,6 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 * Francesco Murdaca (**[@pacospace](https://github.com/pacospace)**), Red Hat
 
 ## Contact
-
-- Slack: [#](https://kubernetes.slack.com/messages/)
-- [Mailing list]()
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fobservability)
 - Steering Committee Liaison: Christoph Görn (**[@goern](https://github.com/goern)**)
 

--- a/community/sig-pipelines/README.md
+++ b/community/sig-pipelines/README.md
@@ -35,9 +35,6 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 * Harshad Nalla (**[@harshad16](https://github.com/harshad16)**), Red Hat
 
 ## Contact
-
-- Slack: [#](https://kubernetes.slack.com/messages/)
-- [Mailing list]()
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fpipelines)
 - Steering Committee Liaison: Christoph Görn (**[@goern](https://github.com/goern)**)
 


### PR DESCRIPTION

## Related Issues and Dependencies

Refactoring #348 (part 2/4)

## This Pull Request implements

This removes the references to Slack and Mailing Lists from the SIG documentation, as they are currently empty and unused.

It also makes these optional in the templates.
