### PR TITLE
Update github-config.yaml

### DIFF
--- a/community/github-config.yaml
+++ b/community/github-config.yaml
@@ -880,6 +880,11 @@ orgs:
       thoth-pybench:
         description: Adopted Python benchmark tool "pybench" - https://openbenchmarking.org/test/pts/pybench
         has_projects: false
+      thoth-search:
+        description: Visualize Python package metadata and browse advisory results.
+        has_projects: false
+        has_wiki: false
+        homepage: https://thoth-station.github.io/search
       thoth-station.github.io:
         description: Project Thoth website
         has_projects: false
@@ -1200,6 +1205,7 @@ orgs:
               thoth-ops: admin
               thoth-ops-infra: admin
               thoth-pybench: admin
+              thoth-search: admin
               thoth-station.github.io: admin
               thoth-toolbox: admin
               twitter-together: admin


### PR DESCRIPTION
## Related Issues and Dependencies
thoth-station/thoth-application/issues/2034

## This introduces a breaking change

- [ ] Yes
- [X] No

## This Pull Request implements

Adding https://github.com/Gkrumbach07/thoth-search to Thoth org.

## Description

This is the first step in integrating Thoth Search into Thoth itself. Other tasks include:

- [ ] transfer ownership (@Gkrumbach07 does not have access to create a repo inside Thoth Station)
- [ ] configure routing under `/search` sub-route.
- [ ] update [CI workflow](https://github.com/Gkrumbach07/thoth-search/blob/master/.github/workflows/continuous-integration-workflow.yml) to work in the new org.