### PR TITLE
Setup a dedicated meetup slot for Thoth observability

### DIFF
--- a/community/sig-list.md
+++ b/community/sig-list.md
@@ -34,7 +34,7 @@ Each group's material is in its subdirectory in this project.
 | Name | Label | Chairs | Contact | Meetings |
 |------|-------|--------|---------|----------|
 |[Docs](sig-docs/README.md)|docs|* [Christoph Görn](https://github.com/goern), Red Hat<br>|* Let's talk Thoth Tech: [Thursdays at 15:00 UTC (Coordinated Universal Time) (weekly)](https://meet.google.com/kxd-axiz-tym)<br>
-|[Observability](sig-observability/README.md)|observability|* [Francesco Murdaca](https://github.com/pacospace), Red Hat<br>|* Let's talk Thoth Tech: [Thursdays at 15:00 UTC (Coordinated Universal Time) (weekly)](https://meet.google.com/kxd-axiz-tym)<br>
+|[Observability](sig-observability/README.md)|observability|* [Francesco Murdaca](https://github.com/pacospace), Red Hat<br>|* Thoth Observability Meeting: [Tuesdays at 14:00 UTC (Coordinated Universal Time) (bi-weekly)](meet.google.com/xaq-nhrm-gaq)<br>
 |[Pipelines](sig-pipelines/README.md)|pipelines|* [Harshad Nalla](https://github.com/harshad16), Red Hat<br>|* Let's talk Thoth Tech: [Thursdays at 15:00 UTC (Coordinated Universal Time) (weekly)](https://meet.google.com/kxd-axiz-tym)<br>
 |[User Experience](sig-user-experience/README.md)|user-experience|* [Christoph Görn](https://github.com/goern), Red Hat<br>|* Let's talk Thoth Tech: [Thursdays at 15:00 UTC (Coordinated Universal Time) (weekly)](https://meet.google.com/kxd-axiz-tym)<br>
 

--- a/community/sig-observability/README.md
+++ b/community/sig-observability/README.md
@@ -17,7 +17,7 @@ Work on all things that concern Observability! This includes the definition of m
 The [charter](charter.md) defines the scope and governance of the Observability Special Interest Group.
 
 ## Meetings
-* Let's talk Thoth Tech: [Thursdays at 15:00 UTC (Coordinated Universal Time)](https://meet.google.com/kxd-axiz-tym) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC%20%28Coordinated%20Universal%20Time%29).
+* Thoth Observability Meeting: [Tuesdays at 14:00 UTC (Coordinated Universal Time)](meet.google.com/xaq-nhrm-gaq) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=UTC%20%28Coordinated%20Universal%20Time%29).
 
 ## Leadership
 

--- a/community/sigs.yaml
+++ b/community/sigs.yaml
@@ -50,12 +50,12 @@ sigs:
           name: Francesco Murdaca
           company: Red Hat
     meetings:
-      - description: Let's talk Thoth Tech
-        day: Thursday
-        time: "15:00"
+      - description: Thoth Observability Meeting
+        day: Tuesday
+        time: "14:00"
         tz: UTC (Coordinated Universal Time)
-        frequency: weekly
-        url: https://meet.google.com/kxd-axiz-tym
+        frequency: bi-weekly
+        url: meet.google.com/xaq-nhrm-gaq
     contact:
       liaison:
         github: goern


### PR DESCRIPTION
Setup a dedicated meetup slot for Thoth observability
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

### Description
This would create a dedicated time slot in the thoth-station community to have a discussion regarding metrics and performance.