### PR TITLE
Add documentation about labels/sig/repo maintenance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,5 +66,7 @@ Automated Community Management
 | GitHub config | |GitHub Config Job| |
 +---------------+---------------------+
 
-.. |Label Sync Job| image:: https://prow.operate-first.cloud/badge.svg?jobs=thoth-station-labels
+.. |Label Sync Job| image:: https://prow.operate-first.cloud/badge.svg?jobs=labels&repo=thoth-station/core
 .. |GitHub Config Job| image:: https://prow.operate-first.cloud/badge.svg?jobs=thoth-station-peribolos
+
+See `community/README.md` for information on automated repository maintenance.

--- a/community/Makefile
+++ b/community/Makefile
@@ -1,4 +1,5 @@
-IMAGE_NAME=golang:1.12
+GOLANG_IMAGE=golang:1.12
+LABEL_SYNC_IMAGE=gcr.io/k8s-prow/label_sync:latest
 export GO111MODULE=on
 export GOPROXY?=https://proxy.golang.org
 
@@ -13,18 +14,19 @@ generate:
 	mv OWNERS_ALIASES ..
 
 generate-dockerized:
-	docker run --rm -e WHAT -e GO111MODULE -e GOPROXY -v $(shell pwd):/go/src/app:Z $(IMAGE_NAME) make -C /go/src/app generate
+	podman run --rm -e WHAT -e GO111MODULE -e GOPROXY -v $(shell pwd):/go/src/app:Z $(GOLANG_IMAGE) make -C /go/src/app generate
+	podman run --rm -v $(shell pwd):/community:Z $(LABEL_SYNC_IMAGE) --action docs --config /community/labels.yaml --docs-template /community/labels.md.tmpl --docs-output /community/labels.md
 
 verify:
 	@hack/verify.sh
 
 verify-dockerized:
-	docker run --rm -v $(shell pwd):/go/src/app:Z $(IMAGE_NAME) make -C /go/src/app verify
+	podman run --rm -v $(shell pwd):/go/src/app:Z $(GOLANG_IMAGE) make -C /go/src/app verify
 
 test:
 	go test -v ./generator/...
 
 test-dockerized:
-	docker run --rm -v $(shell pwd):/go/src/app:Z $(IMAGE_NAME) make -C /go/src/app test
+	podman run --rm -v $(shell pwd):/go/src/app:Z $(GOLANG_IMAGE) make -C /go/src/app test
 
 .PHONY: default reset-docs generate generate-dockerized verify test test-dockerized

--- a/community/README.md
+++ b/community/README.md
@@ -1,0 +1,39 @@
+## Repository configuration
+
+The [github-config.yaml](./github-config.yaml) file contains the details of the
+GitHub configuration for our organization.
+
+This file is used by
+[Peribolos](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/peribolos)
+to apply the configuration to the various repositories. Check the Peribolos
+documentation for more details.
+
+## Updating SIG information
+
+Information about SIGs is sourced from the [sigs.yaml](./sigs.yaml) file.
+
+To generate all the SIG documentation and update the OWNERS files from the
+source file, use the `generate` or `generate-dockerized` targets in the
+[Makefile](./Makefile), e.g.:
+
+```
+make
+```
+
+(`genenerate` is the default target).
+
+This uses the [generator app](https://github.com/kubernetes/community/tree/master/generator) from the
+Kubernetes community.
+
+## Updating labels.md
+
+The [labels.md](./labels.md) file that documents the available labels is
+generated from the source [labels.yaml](./labels.yaml) file that is used by prow to
+maintain the labels on the repos.
+
+To update the document after a change in the source, use the [label_sync](https://github.com/kubernetes/test-infra/tree/master/label_sync) application
+with the `docs` action. An containerized version invocation is included in the [Makefile](./Makefile):
+
+```
+make generate-dockerized
+```


### PR DESCRIPTION
## This Pull Request implements
<!-- Provide a summary of your changes here. -->

Add some basic documentation about `labels.yaml`, `sigs.yaml` and `github-config.yaml` and how to maintain them.

It adds a command to run the label doc generator app.

Also, it replaces `docker` with `podman`.
