### PR TITLE
:exclamation: Peribolos binaries is shifted to /ko-app/ dir

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -25,7 +25,7 @@ presubmits:
             - -c
             - |
               set -ex
-              /peribolos --config-path community/github-config.yaml --github-token-path /etc/github/oauth \
+              /ko-app/peribolos --config-path community/github-config.yaml --github-token-path /etc/github/oauth \
                 --min-admins=2 \
                 --maximum-removal-delta=0.15 \
                 --require-self=true \
@@ -86,7 +86,7 @@ postsubmits:
             - -c
             - |
               set -ex
-              /peribolos --config-path community/github-config.yaml --github-token-path /etc/github/oauth \
+              /ko-app/peribolos --config-path community/github-config.yaml --github-token-path /etc/github/oauth \
                 --min-admins=2 \
                 --maximum-removal-delta=0.15 \
                 --require-self=true \


### PR DESCRIPTION
Peribolos binaries is shifted to /ko-app/ dir
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/kubernetes/test-infra/issues/25440

### Description
https://github.com/kubernetes/test-infra/blob/master/prow/ANNOUNCEMENTS.md?plain=1#L195
