### PR TITLE
Set SP-pipelines meeting to weekly

### DIFF
--- a/community/sig-devsecops/README.md
+++ b/community/sig-devsecops/README.md
@@ -49,7 +49,7 @@ A set of base images and pipelines to build application container images
   - https://raw.githubusercontent.com/thoth-station/pipeline-helpers/master/OWNERS
   - https://raw.githubusercontent.com/thoth-station/thoth-ops-infra/master/OWNERS
 - **Meetings:**
-  - Pipelines Meeting: [Thursdays at 12:00 ET (Eastern Time)](https://meet.google.com/ozb-tbrp-agx) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:00&tz=ET%20%28Eastern%20Time%29).
+  - Pipelines Meeting: [Thursdays at 12:00 ET (Eastern Time)](https://meet.google.com/ozb-tbrp-agx) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:00&tz=ET%20%28Eastern%20Time%29).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/16EIdTs12apkjuNlgBCMa0gQ2Gd0CFu9wn-N9GQmwTdw/edit#).
 ### opf-ci-prow
 Continuous Integration infrastructure for the project, using prow

--- a/community/sig-list.md
+++ b/community/sig-list.md
@@ -33,7 +33,7 @@ Each group's material is in its subdirectory in this project.
 
 | Name | Label | Chairs | Contact | Meetings |
 |------|-------|--------|---------|----------|
-|[DevSecOps](sig-devsecops/README.md)|devsecops|* [Harshad Nalla](https://github.com/harshad16), Red Hat<br>|* (build-pipelines) Pipelines Meeting: [Thursdays at 12:00 ET (Eastern Time) (bi-weekly)](https://meet.google.com/ozb-tbrp-agx)<br>* (thoth-application) Thoth Release Meeting: [Wednesdays at 14:00 UTC (Coordinated Universal Time) (bi-weekly)](https://meet.google.com/kro-zbcc-xpd)<br>
+|[DevSecOps](sig-devsecops/README.md)|devsecops|* [Harshad Nalla](https://github.com/harshad16), Red Hat<br>|* (build-pipelines) Pipelines Meeting: [Thursdays at 12:00 ET (Eastern Time) (weekly)](https://meet.google.com/ozb-tbrp-agx)<br>* (thoth-application) Thoth Release Meeting: [Wednesdays at 14:00 UTC (Coordinated Universal Time) (bi-weekly)](https://meet.google.com/kro-zbcc-xpd)<br>
 |[Observability](sig-observability/README.md)|observability|* [Francesco Murdaca](https://github.com/pacospace), Red Hat<br>|* Thoth Observability Meeting: [Tuesdays at 14:00 UTC (Coordinated Universal Time) (bi-weekly)](meet.google.com/xaq-nhrm-gaq)<br>
 |[Stack Guidance](sig-stack-guidance/README.md)|stack-guidance|* [Fridolín Pokorný](https://github.com/fridex), Red Hat<br>|* SIG Stack Guidance Meeting: [Mondays at 14:00 UTC (Coordinated Universal Time) (weekly)](meet.google.com/umj-bgfi-ouo)<br>
 |[User Experience](sig-user-experience/README.md)|user-experience|* [Christoph Görn](https://github.com/goern), Red Hat<br>|* Let's talk Thoth Tech: [Thursdays at 15:00 UTC (Coordinated Universal Time) (weekly)](https://meet.google.com/kxd-axiz-tym)<br>

--- a/community/sigs.yaml
+++ b/community/sigs.yaml
@@ -40,7 +40,7 @@ sigs:
       day: Thursday
       time: "12:00"
       tz: ET (Eastern Time)
-      frequency: bi-weekly
+      frequency: weekly
       url: https://meet.google.com/ozb-tbrp-agx
       archive_url: https://docs.google.com/document/d/16EIdTs12apkjuNlgBCMa0gQ2Gd0CFu9wn-N9GQmwTdw/edit#
   - name: opf-ci-prow


### PR DESCRIPTION
We switched the SP-Pipelines meeting to a weekly cadence for the time being.

This PR is to update the SIG documentation accordingly - just that change from bi-weekly to weekly.