### PR TITLE
Remove the needs-triage label from the templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: "kind/bug, needs-triage"
+labels: kind/bug
 ---
 ## Bug description
 <!-- A clear and concise description of what the bug is. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: "kind/feature, needs-triage"
+labels: kind/feature
 ---
 ## Problem statement
 <!-- Is your feature request related to a problem? Please provide a clear and concise description of what the problem is.


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->

Related to https://github.com/thoth-station/thoth-application/issues/2359

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
<!-- Provide a summary of your changes here. -->

Remove the `needs-triage` label from the GitHub issue templates, so that it does not get added directly upon issue creation.

### Description
<!--- Describe your changes in detail here. -->

The `needs-triage` label is managed by prow, which also adds helpful messages where appropriate.

Having the label in the template prevents these messages.