### PR TITLE
Make peribolos and label_sync use ghproxy

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -26,6 +26,8 @@ presubmits:
             - |
               set -ex
               /ko-app/peribolos --config-path community/github-config.yaml --github-token-path /etc/github/oauth \
+                --github-endpoint=http://ghproxy \
+                --github-endpoint=https://api.github.com \
                 --min-admins=2 \
                 --maximum-removal-delta=0.15 \
                 --require-self=true \
@@ -58,9 +60,11 @@ presubmits:
             - |
               set -ex
               /ko-app/label_sync \
-              --config=community/labels.yaml \
-              --orgs=thoth-station \
-              --token=/etc/github/oauth
+                --github-endpoint=http://ghproxy \
+                --github-endpoint=https://api.github.com \
+                --config=community/labels.yaml \
+                --orgs=thoth-station \
+                --token=/etc/github/oauth
           volumeMounts:
             - name: github-oauth
               mountPath: /etc/github
@@ -87,6 +91,8 @@ postsubmits:
             - |
               set -ex
               /ko-app/peribolos --config-path community/github-config.yaml --github-token-path /etc/github/oauth \
+                --github-endpoint=http://ghproxy \
+                --github-endpoint=https://api.github.com \
                 --min-admins=2 \
                 --maximum-removal-delta=0.15 \
                 --require-self=true \
@@ -122,10 +128,12 @@ postsubmits:
             - |
               set -ex
               /ko-app/label_sync \
-              --config=community/labels.yaml \
-              --orgs=thoth-station  \
-              --token=/etc/github/oauth \
-              --confirm
+                --github-endpoint=http://ghproxy \
+                --github-endpoint=https://api.github.com \
+                --config=community/labels.yaml \
+                --orgs=thoth-station  \
+                --token=/etc/github/oauth \
+                --confirm
           volumeMounts:
             - name: github-oauth
               mountPath: /etc/github


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->

Fixes: #406

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
<!-- Provide a summary of your changes here. -->

Add a `--github-endpoint` to *peribolos* and *label_sync* prow jobs so that they use the local `ghproxy` instance.

### Description
<!--- Describe your changes in detail here. -->

See https://github.com/kubernetes/test-infra/tree/master/ghproxy#ghproxy