### PR TITLE
[prow] Fix label_sync token argument name

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -64,7 +64,7 @@ presubmits:
                 --github-endpoint=https://api.github.com \
                 --config=community/labels.yaml \
                 --orgs=thoth-station \
-                --token=/etc/github/oauth
+                --github-token-path=/etc/github/oauth
           volumeMounts:
             - name: github-oauth
               mountPath: /etc/github
@@ -132,7 +132,7 @@ postsubmits:
                 --github-endpoint=https://api.github.com \
                 --config=community/labels.yaml \
                 --orgs=thoth-station  \
-                --token=/etc/github/oauth \
+                --github-token-path=/etc/github/oauth \
                 --confirm
           volumeMounts:
             - name: github-oauth

--- a/community/labels.yaml
+++ b/community/labels.yaml
@@ -98,8 +98,9 @@ default:
 
     - color: d5f48d
       description: This Issue or PR is related to a specific deployment.
-      name: deployment_name/zero-prod
+      name: deployment_name/prod
       previously:
+        - name: deployment_name/zero-prod
         - name: deployment_name/moc
       target: both
       prowPlugin: label


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->

Follow-up after #407

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
<!-- Provide a summary of your changes here. -->

Use `--github-token-path` instead of `--token` as an argument for `label_sync`.

### Description
<!--- Describe your changes in detail here. -->

After adding the `--github-*` parameters to use *ghproxy* in #407, `label_sync` is not running, complaining about:

``` json
+ /ko-app/label_sync '--github-endpoint=http://ghproxy' '--github-endpoint=https://api.github.com' '--config=community/labels.yaml' '--orgs=thoth-station' '--token=/etc/github/oauth' --confirm
{"component":"label_sync","file":"k8s.io/test-infra/label_sync/main.go:178","func":"main.gatherOptions","level":"fatal","msg":"deprecated GitHub options, include --endpoint, --graphql-endpoint, --token, --tokens, --token-burst cannot be combined with new --github-XXX counterparts","severity":"fatal","time":"2022-05-10T11:11:17Z"}
```