### PR TITLE
Enable projects for thoth-station/support && thoth-station/srcops-testing

### DIFF
--- a/community/github-config.yaml
+++ b/community/github-config.yaml
@@ -860,7 +860,7 @@ orgs:
         has_wiki: false
       support:
         description: "ℹ Any Thoth related support questions"
-        has_projects: false
+        has_projects: true
         has_wiki: false
       sync-job:
         description: A one time job to sync all Thoth data

--- a/community/github-config.yaml
+++ b/community/github-config.yaml
@@ -826,7 +826,7 @@ orgs:
         has_wiki: false
       srcops-testing:
         description: This is a SrcOps test repository
-        has_projects: false
+        has_projects: true
         has_wiki: false
       statusfy:
         description: I show the status of services of the Thoth Station


### PR DESCRIPTION
## Related Issues and Dependencies
Related to https://github.com/thoth-station/srcops-testing/issues/265#issuecomment-1168633204
and https://github.com/thoth-station/mi/issues/589

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

### Description
Enable projects feature for `thoth-station/support` repository, so that we can collect project-related events through the Github Issue Events API
