### PR TITLE
Update SIG DevSecOps and Observability metadata

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,8 +7,7 @@ aliases:
     - fridex
     - mayaCostantini
   sig-user-experience-leads:
-    - goern
-    - pacospace
+    - Gkrumbach07
 ## BEGIN CUSTOM CONTENT
 
 ## END CUSTOM CONTENT

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,7 +2,7 @@ aliases:
   sig-devsecops-leads:
     - harshad16
   sig-observability-leads:
-    - pacospace
+    - harshad16
   sig-stack-guidance-leads:
     - fridex
     - mayaCostantini

--- a/community/sig-devsecops/README.md
+++ b/community/sig-devsecops/README.md
@@ -17,7 +17,9 @@ This includes the discussion related to the release process of the Thoth-Station
 
 The [charter](charter.md) defines the scope and governance of the DevSecOps Special Interest Group.
 
-
+## Meetings
+* Thoth DevSecOps Meeting: [Thursdays at 15:30 UTC (Coordinated Universal Time)](https://meet.google.com/ozb-tbrp-agx) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:30&tz=UTC%20%28Coordinated%20Universal%20Time%29).
+  * [Meeting notes and Agenda](https://docs.google.com/document/d/16EIdTs12apkjuNlgBCMa0gQ2Gd0CFu9wn-N9GQmwTdw/edit).
 
 ## Leadership
 
@@ -48,9 +50,6 @@ A set of base images and pipelines to build application container images
   - https://raw.githubusercontent.com/thoth-station/helm-charts/master/OWNERS
   - https://raw.githubusercontent.com/thoth-station/pipeline-helpers/master/OWNERS
   - https://raw.githubusercontent.com/thoth-station/thoth-ops-infra/master/OWNERS
-- **Meetings:**
-  - Pipelines Meeting: [Thursdays at 12:00 ET (Eastern Time)](https://meet.google.com/ozb-tbrp-agx) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:00&tz=ET%20%28Eastern%20Time%29).
-    - [Meeting notes and Agenda](https://docs.google.com/document/d/16EIdTs12apkjuNlgBCMa0gQ2Gd0CFu9wn-N9GQmwTdw/edit#).
 ### opf-ci-prow
 Continuous Integration infrastructure for the project, using prow
 - **Owners:**
@@ -59,9 +58,6 @@ Continuous Integration infrastructure for the project, using prow
 Release management for Thoth components
 - **Owners:**
   - https://raw.githubusercontent.com/thoth-station/thoth-application/master/OWNERS
-- **Meetings:**
-  - Thoth Release Meeting: [Wednesdays at 14:00 UTC (Coordinated Universal Time)](https://meet.google.com/kro-zbcc-xpd) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=UTC%20%28Coordinated%20Universal%20Time%29).
-    - [Meeting notes and Agenda](https://docs.google.com/document/d/1jSDY8tzQ4a1RHiXdIHgS0ywkkpQDJdKpTJWM6u1Z5iM/edit).
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/community/sig-devsecops/README.md
+++ b/community/sig-devsecops/README.md
@@ -43,21 +43,37 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-devsecops:
-### build-pipelines
+### Notebooks
+A set of base images that are useful for Data Science work
+- **Owners:**
+  - https://raw.githubusercontent.com/thoth-station/ps-cv/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/ps-ip/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/ps-nlp/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/ray-ml-notebook/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/ray-ml-worker/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/ray-operator/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/s2i-data-science-notebook/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/s2i-minimal-notebook/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/s2i-pytorch-notebook/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/s2i-scipy-notebook/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/s2i-tensorflow-gpu-notebook/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/s2i-tensorflow-notebook/master/OWNERS
+### Pipelines
 A set of base images and pipelines to build application container images
 - **Owners:**
   - https://raw.githubusercontent.com/AICoE/aicoe-ci/master/OWNERS
   - https://raw.githubusercontent.com/thoth-station/helm-charts/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/jupyternb-build-pipeline/master/OWNERS
   - https://raw.githubusercontent.com/thoth-station/pipeline-helpers/master/OWNERS
-  - https://raw.githubusercontent.com/thoth-station/thoth-ops-infra/master/OWNERS
-### opf-ci-prow
-Continuous Integration infrastructure for the project, using prow
+### Services
+Tooling and configuration to manage the releases of various Thoth services and components
 - **Owners:**
-  - https://raw.githubusercontent.com/thoth-station/thoth-application/master/prow/OWNERS
-### thoth-application
-Release management for Thoth components
-- **Owners:**
+  - https://raw.githubusercontent.com/AICoE/sefkhet-abwy/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/OWNERS
   - https://raw.githubusercontent.com/thoth-station/thoth-application/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/thoth-ops-infra/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/thoth-ops/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/thoth-toolbox/master/OWNERS
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/community/sig-list.md
+++ b/community/sig-list.md
@@ -33,8 +33,8 @@ Each group's material is in its subdirectory in this project.
 
 | Name | Label | Chairs | Contact | Meetings |
 |------|-------|--------|---------|----------|
-|[DevSecOps](sig-devsecops/README.md)|devsecops|* [Harshad Nalla](https://github.com/harshad16), Red Hat<br>|* (build-pipelines) Pipelines Meeting: [Thursdays at 12:00 ET (Eastern Time) (weekly)](https://meet.google.com/ozb-tbrp-agx)<br>* (thoth-application) Thoth Release Meeting: [Wednesdays at 14:00 UTC (Coordinated Universal Time) (bi-weekly)](https://meet.google.com/kro-zbcc-xpd)<br>
-|[Observability](sig-observability/README.md)|observability|* [Francesco Murdaca](https://github.com/pacospace), Red Hat<br>|* Thoth Observability Meeting: [Tuesdays at 14:00 UTC (Coordinated Universal Time) (bi-weekly)](meet.google.com/xaq-nhrm-gaq)<br>
+|[DevSecOps](sig-devsecops/README.md)|devsecops|* [Harshad Nalla](https://github.com/harshad16), Red Hat<br>|* Thoth DevSecOps Meeting: [Thursdays at 15:30 UTC (Coordinated Universal Time) (weekly)](https://meet.google.com/ozb-tbrp-agx)<br>
+|[Observability](sig-observability/README.md)|observability|* [Harshad Nalla](https://github.com/harshad16), Red Hat<br>|* Thoth Observability Meeting (joint with DevSecOps): [Thursdays at 15:30 UTC (Coordinated Universal Time) (weekly)](https://meet.google.com/ozb-tbrp-agx)<br>
 |[Stack Guidance](sig-stack-guidance/README.md)|stack-guidance|* [Fridolín Pokorný](https://github.com/fridex), Red Hat<br>* [Maya Costantini](https://github.com/mayaCostantini), Red Hat<br>|* SIG Stack Guidance Meeting: [Mondays at 14:00 UTC (Coordinated Universal Time) (weekly)](meet.google.com/umj-bgfi-ouo)<br>
 |[User Experience](sig-user-experience/README.md)|user-experience|* [Gage Krumbach](https://github.com/Gkrumbach07), Red Hat<br>|* SIG User Experience Office Hours: [Tuesdays at 13:00 UTC (Coordinated Universal Time) (weekly)](https://meet.google.com/cde-iczf-zso)<br>
 

--- a/community/sig-list.md
+++ b/community/sig-list.md
@@ -36,7 +36,7 @@ Each group's material is in its subdirectory in this project.
 |[DevSecOps](sig-devsecops/README.md)|devsecops|* [Harshad Nalla](https://github.com/harshad16), Red Hat<br>|* (build-pipelines) Pipelines Meeting: [Thursdays at 12:00 ET (Eastern Time) (weekly)](https://meet.google.com/ozb-tbrp-agx)<br>* (thoth-application) Thoth Release Meeting: [Wednesdays at 14:00 UTC (Coordinated Universal Time) (bi-weekly)](https://meet.google.com/kro-zbcc-xpd)<br>
 |[Observability](sig-observability/README.md)|observability|* [Francesco Murdaca](https://github.com/pacospace), Red Hat<br>|* Thoth Observability Meeting: [Tuesdays at 14:00 UTC (Coordinated Universal Time) (bi-weekly)](meet.google.com/xaq-nhrm-gaq)<br>
 |[Stack Guidance](sig-stack-guidance/README.md)|stack-guidance|* [Fridolín Pokorný](https://github.com/fridex), Red Hat<br>* [Maya Costantini](https://github.com/mayaCostantini), Red Hat<br>|* SIG Stack Guidance Meeting: [Mondays at 14:00 UTC (Coordinated Universal Time) (weekly)](meet.google.com/umj-bgfi-ouo)<br>
-|[User Experience](sig-user-experience/README.md)|user-experience|* [Christoph Görn](https://github.com/goern), Red Hat<br>|* Let's talk Thoth Tech: [Thursdays at 15:00 UTC (Coordinated Universal Time) (weekly)](https://meet.google.com/kxd-axiz-tym)<br>
+|[User Experience](sig-user-experience/README.md)|user-experience|* [Gage Krumbach](https://github.com/Gkrumbach07), Red Hat<br>|* SIG User Experience Office Hours: [Tuesdays at 13:00 UTC (Coordinated Universal Time) (weekly)](https://meet.google.com/cde-iczf-zso)<br>
 
 ### Committees
 

--- a/community/sig-observability/README.md
+++ b/community/sig-observability/README.md
@@ -41,21 +41,13 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-observability:
-### advise-reporter
+### Monitoring
 - **Owners:**
   - https://raw.githubusercontent.com/thoth-station/advise-reporter/master/OWNERS
-### investigator-exporter
-- **Owners:**
   - https://raw.githubusercontent.com/thoth-station/investigator/master/OWNERS
-### metrics-exporter
-- **Owners:**
   - https://raw.githubusercontent.com/thoth-station/metrics-exporter/master/OWNERS
-### monitoring/alerting
-- **Owners:**
-  - https://raw.githubusercontent.com/thoth-station/thoth-application/master/monitoring/OWNERS
-### slo-reporter
-- **Owners:**
   - https://raw.githubusercontent.com/thoth-station/slo-reporter/master/OWNERS
+  - https://raw.githubusercontent.com/thoth-station/thoth-application/master/monitoring/OWNERS
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/community/sig-observability/README.md
+++ b/community/sig-observability/README.md
@@ -17,7 +17,7 @@ Work on all things that concern Observability! This includes the definition of m
 The [charter](charter.md) defines the scope and governance of the Observability Special Interest Group.
 
 ## Meetings
-* Thoth Observability Meeting: [Tuesdays at 14:00 UTC (Coordinated Universal Time)](meet.google.com/xaq-nhrm-gaq) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=UTC%20%28Coordinated%20Universal%20Time%29).
+* Thoth Observability Meeting (joint with DevSecOps): [Thursdays at 15:30 UTC (Coordinated Universal Time)](https://meet.google.com/ozb-tbrp-agx) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:30&tz=UTC%20%28Coordinated%20Universal%20Time%29).
 
 ## Leadership
 
@@ -25,14 +25,14 @@ The [charter](charter.md) defines the scope and governance of the Observability 
 
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Francesco Murdaca (**[@pacospace](https://github.com/pacospace)**), Red Hat
+* Harshad Nalla (**[@harshad16](https://github.com/harshad16)**), Red Hat
 
 ### Technical Leads
 
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
-* Francesco Murdaca (**[@pacospace](https://github.com/pacospace)**), Red Hat
+* Harshad Nalla (**[@harshad16](https://github.com/harshad16)**), Red Hat
 
 ## Contact
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fobservability)

--- a/community/sig-user-experience/README.md
+++ b/community/sig-user-experience/README.md
@@ -17,7 +17,8 @@ The User Experience SIG focuses on the interaction points between end users and 
 The [charter](charter.md) defines the scope and governance of the User Experience Special Interest Group.
 
 ## Meetings
-* Let's talk Thoth Tech: [Thursdays at 15:00 UTC (Coordinated Universal Time)](https://meet.google.com/kxd-axiz-tym) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC%20%28Coordinated%20Universal%20Time%29).
+* SIG User Experience Office Hours: [Tuesdays at 13:00 UTC (Coordinated Universal Time)](https://meet.google.com/cde-iczf-zso) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=UTC%20%28Coordinated%20Universal%20Time%29).
+  * [Meeting notes and Agenda](https://docs.google.com/document/d/1shJ5C_1Z3RT-mFdnrDmntIxGj5BmdlACfrwxoKd0CSY/edit).
 
 ## Leadership
 
@@ -25,14 +26,14 @@ The [charter](charter.md) defines the scope and governance of the User Experienc
 
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Christoph Görn (**[@goern](https://github.com/goern)**), Red Hat
+* Gage Krumbach (**[@Gkrumbach07](https://github.com/Gkrumbach07)**), Red Hat
 
 ### Technical Leads
 
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
-* Francesco Murdaca (**[@pacospace](https://github.com/pacospace)**), Red Hat
+* Gage Krumbach (**[@Gkrumbach07](https://github.com/Gkrumbach07)**), Red Hat
 
 ## Contact
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fuser-experience)

--- a/community/sigs.yaml
+++ b/community/sigs.yaml
@@ -34,23 +34,39 @@ sigs:
       github: goern
       name: Christoph Görn
   subprojects:
-  - name: build-pipelines
+  - name: Notebooks
+    description: A set of base images that are useful for Data Science work
+    owners:
+    - https://raw.githubusercontent.com/thoth-station/ps-cv/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/ps-ip/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/ps-nlp/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/ray-ml-notebook/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/ray-ml-worker/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/ray-operator/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/s2i-data-science-notebook/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/s2i-minimal-notebook/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/s2i-pytorch-notebook/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/s2i-scipy-notebook/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/s2i-tensorflow-gpu-notebook/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/s2i-tensorflow-notebook/master/OWNERS
+  - name: Pipelines
     description: |
       A set of base images and pipelines to build application container images
     owners:
     - https://raw.githubusercontent.com/AICoE/aicoe-ci/master/OWNERS
     - https://raw.githubusercontent.com/thoth-station/helm-charts/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/jupyternb-build-pipeline/master/OWNERS
     - https://raw.githubusercontent.com/thoth-station/pipeline-helpers/master/OWNERS
-    - https://raw.githubusercontent.com/thoth-station/thoth-ops-infra/master/OWNERS
-  - name: opf-ci-prow
-    description: |
-      Continuous Integration infrastructure for the project, using prow
+  - name: Services
+    description: Tooling and configuration to manage the releases of various Thoth
+      services and components
     owners:
-    - https://raw.githubusercontent.com/thoth-station/thoth-application/master/prow/OWNERS
-  - name: thoth-application
-    description: Release management for Thoth components
-    owners:
+    - https://raw.githubusercontent.com/AICoE/sefkhet-abwy/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/OWNERS
     - https://raw.githubusercontent.com/thoth-station/thoth-application/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/thoth-ops-infra/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/thoth-ops/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/thoth-toolbox/master/OWNERS
 - dir: sig-observability
   name: Observability
   mission_statement: >
@@ -80,21 +96,13 @@ sigs:
       github: goern
       name: Christoph Görn
   subprojects:
-  - name: advise-reporter
+  - name: Monitoring
     owners:
     - https://raw.githubusercontent.com/thoth-station/advise-reporter/master/OWNERS
-  - name: investigator-exporter
-    owners:
     - https://raw.githubusercontent.com/thoth-station/investigator/master/OWNERS
-  - name: metrics-exporter
-    owners:
     - https://raw.githubusercontent.com/thoth-station/metrics-exporter/master/OWNERS
-  - name: monitoring/alerting
-    owners:
-    - https://raw.githubusercontent.com/thoth-station/thoth-application/master/monitoring/OWNERS
-  - name: slo-reporter
-    owners:
     - https://raw.githubusercontent.com/thoth-station/slo-reporter/master/OWNERS
+    - https://raw.githubusercontent.com/thoth-station/thoth-application/master/monitoring/OWNERS
 - dir: sig-stack-guidance
   name: Stack Guidance
   mission_statement: >

--- a/community/sigs.yaml
+++ b/community/sigs.yaml
@@ -21,7 +21,14 @@ sigs:
     - github: harshad16
       name: Harshad Nalla
       company: Red Hat
-  meetings: []
+  meetings:
+  - description: Thoth DevSecOps Meeting
+    day: Thursday
+    time: "15:30"
+    tz: UTC (Coordinated Universal Time)
+    frequency: weekly
+    url: https://meet.google.com/ozb-tbrp-agx
+    archive_url: https://docs.google.com/document/d/16EIdTs12apkjuNlgBCMa0gQ2Gd0CFu9wn-N9GQmwTdw/edit
   contact:
     liaison:
       github: goern
@@ -35,14 +42,6 @@ sigs:
     - https://raw.githubusercontent.com/thoth-station/helm-charts/master/OWNERS
     - https://raw.githubusercontent.com/thoth-station/pipeline-helpers/master/OWNERS
     - https://raw.githubusercontent.com/thoth-station/thoth-ops-infra/master/OWNERS
-    meetings:
-    - description: Pipelines Meeting
-      day: Thursday
-      time: "12:00"
-      tz: ET (Eastern Time)
-      frequency: weekly
-      url: https://meet.google.com/ozb-tbrp-agx
-      archive_url: https://docs.google.com/document/d/16EIdTs12apkjuNlgBCMa0gQ2Gd0CFu9wn-N9GQmwTdw/edit#
   - name: opf-ci-prow
     description: |
       Continuous Integration infrastructure for the project, using prow
@@ -52,14 +51,6 @@ sigs:
     description: Release management for Thoth components
     owners:
     - https://raw.githubusercontent.com/thoth-station/thoth-application/master/OWNERS
-    meetings:
-    - description: Thoth Release Meeting
-      day: Wednesday
-      time: "14:00"
-      tz: UTC (Coordinated Universal Time)
-      frequency: bi-weekly
-      url: https://meet.google.com/kro-zbcc-xpd
-      archive_url: https://docs.google.com/document/d/1jSDY8tzQ4a1RHiXdIHgS0ywkkpQDJdKpTJWM6u1Z5iM/edit
 - dir: sig-observability
   name: Observability
   mission_statement: >
@@ -70,20 +61,20 @@ sigs:
   label: observability
   leadership:
     chairs:
-    - github: pacospace
-      name: Francesco Murdaca
+    - github: harshad16
+      name: Harshad Nalla
       company: Red Hat
     tech_leads:
-    - github: pacospace
-      name: Francesco Murdaca
+    - github: harshad16
+      name: Harshad Nalla
       company: Red Hat
   meetings:
-  - description: Thoth Observability Meeting
-    day: Tuesday
-    time: "14:00"
+  - description: Thoth Observability Meeting (joint with DevSecOps)
+    day: Thursday
+    time: "15:30"
     tz: UTC (Coordinated Universal Time)
-    frequency: bi-weekly
-    url: meet.google.com/xaq-nhrm-gaq
+    frequency: weekly
+    url: https://meet.google.com/ozb-tbrp-agx
   contact:
     liaison:
       github: goern

--- a/community/sigs.yaml
+++ b/community/sigs.yaml
@@ -159,20 +159,21 @@ sigs:
   label: user-experience
   leadership:
     chairs:
-    - github: goern
-      name: Christoph Görn
+    - github: Gkrumbach07
+      name: Gage Krumbach
       company: Red Hat
     tech_leads:
-    - github: pacospace
-      name: Francesco Murdaca
+    - github: Gkrumbach07
+      name: Gage Krumbach
       company: Red Hat
   meetings:
-  - description: Let's talk Thoth Tech
-    day: Thursday
-    time: "15:00"
+  - description: SIG User Experience Office Hours
+    day: Tuesday
+    time: "13:00"
     tz: UTC (Coordinated Universal Time)
     frequency: weekly
-    url: https://meet.google.com/kxd-axiz-tym
+    url: https://meet.google.com/cde-iczf-zso
+    archive_url: https://docs.google.com/document/d/1shJ5C_1Z3RT-mFdnrDmntIxGj5BmdlACfrwxoKd0CSY/edit
   contact:
     liaison:
       github: goern


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->

Note that this PR includes the commit from #421. It is expected to merge after that other (simpler) update.

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
<!-- Provide a summary of your changes here. -->

Update SIG information for DevSecOps and Observability.

### Description
<!--- Describe your changes in detail here. -->

On one hand, this updates information about current meetings and members of the team.

Also, in the SIG-DevSecOps meeting on 2022-07-07 there was a review of the repos associated with SIG-DevSecOps, and this PR adds the updated list of repos for the SIG.

The sub-projects where repos belong also are updated to reflect the grouping.