### PR TITLE
Allow admins to write privileges on odh-dashboard repo

### DIFF
--- a/community/github-config.yaml
+++ b/community/github-config.yaml
@@ -1091,6 +1091,7 @@ orgs:
           misc: triage
           nepthys: triage
           notebooks: triage
+          odh-dashboard: triage
           odo-devfiles-registry: triage
           openblas: triage
           opendatahub-cnbi: triage
@@ -1220,6 +1221,7 @@ orgs:
           misc: write
           nepthys: write
           notebooks: write
+          odh-dashboard: write
           odo-devfiles-registry: write
           openblas: write
           opendatahub-cnbi: write


### PR DESCRIPTION
Allow admins to write privileges on odh-dashboard repo
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
